### PR TITLE
Install Docker 17.09 RC

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ENV['HOME'], ENV['HOME']
 
-#  config.vm.provision "shell", path: "scripts/load-images.ps1"
+  config.vm.provision "shell", path: "scripts/update-docker-rc.ps1"
   config.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{ENV['HOME']} -machineName insider"
   config.vm.provision "shell", path: "scripts/install-hyperv.ps1"
   config.vm.provision "reload"

--- a/scripts/create-machine.ps1
+++ b/scripts/create-machine.ps1
@@ -9,7 +9,7 @@ $ipAddresses = ((Get-NetIPAddress -AddressFamily IPv4).IPAddress) -Join ','
 if (!$machineIp) {
   $machineIp=(Get-NetIPAddress -AddressFamily IPv4 `
     | Where-Object -FilterScript { `
-      ( ! ($_.InterfaceAlias).StartsWith("vEthernet (HNS Internal NIC)") ) `
+      ( ! ($_.InterfaceAlias).StartsWith("vEthernet (") ) `
       -And $_.IPAddress -Ne "127.0.0.1" `
       -And $_.IPAddress -Ne "10.0.2.15" `
     }).IPAddress

--- a/scripts/load-images.ps1
+++ b/scripts/load-images.ps1
@@ -1,4 +1,0 @@
-cd C:\Users\stefan\code\insider
-Start-Sleep 30
-docker import CBaseOs_rs_prerelease_16237.1001.170701-0549_amd64fre_NanoServer_en-us.tar.gz microsoft/nanoserver
-docker import CBaseOs_rs_prerelease_16237.1001.170701-0549_amd64fre_ServerDatacenterCore_en-us.tar.gz microsoft/windowsservercore

--- a/scripts/update-docker-rc.ps1
+++ b/scripts/update-docker-rc.ps1
@@ -1,0 +1,22 @@
+Write-Host "Stopping docker service"
+Stop-Service docker
+$version = "17.09.0-ce-rc1"
+
+Write-Host "Downloading docker-$version.zip"
+$wc = New-Object net.webclient
+$wc.DownloadFile("https://download.docker.com/win/static/test/x86_64/docker-$version.zip", "$env:TEMP\docker-$version.zip")
+Write-Host "Extracting docker-$version.zip"
+Expand-Archive -Path "$env:TEMP\docker-$version.zip" -DestinationPath $env:ProgramFiles -Force
+Remove-Item "$env:TEMP\docker-$version.zip"
+
+Write-Host "Activating experimental features"
+$daemonJson = "$env:ProgramData\docker\config\daemon.json"
+$config = @{}
+if (Test-Path $daemonJson) {
+  $config = (Get-Content $daemonJson) -join "`n" | ConvertFrom-Json
+}
+$config = $config | Add-Member(@{ experimental = $true }) -Force -PassThru
+$config | ConvertTo-Json | Set-Content $daemonJson -Encoding Ascii
+
+Write-Host "Starting docker service"
+Start-Service docker


### PR DESCRIPTION
To use the latest features like mapping named pipes into Windows containers ( moby/moby#33852 ) we need to update to Docker 17.09.0-ce-rc1.

```
$ docker run -u ContainerAdministrator -v '\\.\pipe\docker_engine:\\.\pipe\docker_engine' stefanscherer/docker-cli-windows:insider images
Unable to find image 'stefanscherer/docker-cli-windows:insider' locally
insider: Pulling from stefanscherer/docker-cli-windows
3cda982da924: Already exists 
8bcef649df07: Pull complete 
94f28b5b4c4f: Pull complete 
Digest: sha256:6fd09a2174415ea8caf59849ed351e7a7a2aeb3165ffe83b6c652f77c6e6f658
Status: Downloaded newer image for stefanscherer/docker-cli-windows:insider
REPOSITORY                            TAG                 IMAGE ID            CREATED             SIZE
stefanscherer/docker-cli-windows      insider             9704fcbfec6a        40 hours ago        220MB
microsoft/windowsservercore-insider   latest              78f9e9fa237f        5 days ago          4.59GB
microsoft/nanoserver-insider          latest              58800bc4b5e0        5 days ago          200MB
```

