### PR TITLE
Add optional steps to enable LCOW

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ packer build --only=vmware-iso --var iso_url=~/Downloads/Windows_InsiderPreview_
 vagrant box add windows_2016_insider windows_2016_insider_vmware.box
 ```
 
-This Vagrant box has Docker 17.09.0-ce-rc1 installed and the following base images are already pulled from Docker Hub:
+This Vagrant box has Docker 17.09.0-ce-rc2 installed and the following base images are already pulled from Docker Hub:
 
   * microsoft/windowsservercore-insider
   * microsoft/nanoserver-insider
@@ -55,3 +55,16 @@ docker images
 ```
 eval $(docker-machine env -unset)
 ```
+
+## LCOW - Linux Container on Windows
+
+With this Windows Insider and the nightly version of the Docker engine for Windows you also can get in touch with the preview of LCOW. Running Linux containers on Windows
+
+To have LCOW activated, prepare the `Vagrantfile` with these two provision scripts.
+
+```
+  config.vm.provision "shell", path: "scripts/update-nightly-docker.ps1"
+  config.vm.provision "shell", path: "scripts/install-linuxkit.ps1"
+```
+
+Now run `vagrant up` and you are able to try out the first preview of LCOW.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,13 +14,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision "shell", path: "scripts/update-docker-rc.ps1"
   config.vm.provision "shell", path: "scripts/create-machine.ps1", args: "-machineHome #{ENV['HOME']} -machineName insider"
+  # Activate the next two lines to test LCOW
+  # config.vm.provision "shell", path: "scripts/update-nightly-docker.ps1"
+  # config.vm.provision "shell", path: "scripts/install-linuxkit.ps1"
   config.vm.provision "shell", path: "scripts/install-hyperv.ps1"
   config.vm.provision "reload"
 
   ["vmware_fusion", "vmware_workstation"].each do |provider|
     config.vm.provider provider do |v, override|
       v.gui = false
-      v.memory = 2048
+      v.memory = 4096
       v.cpus = 2
       v.enable_vmrun_ip_lookup = false
       v.linked_clone = true
@@ -30,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |v, override|
     v.gui = false
-    v.memory = 2048
+    v.memory = 4096
     v.cpus = 2
     v.linked_clone = true
     override.vm.network :private_network, ip: "192.168.99.90", gateway: "192.168.99.1"
@@ -38,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "hyperv" do |v|
     v.cpus = 2
-    v.maxmemory = 2048
+    v.maxmemory = 4096
     v.differencing_disk = true
   end
 end

--- a/scripts/install-linuxkit.ps1
+++ b/scripts/install-linuxkit.ps1
@@ -10,4 +10,4 @@ rm $Env:Temp\linuxkit.zip
 
 [Environment]::SetEnvironmentVariable("LCOW_SUPPORTED", "1", "Machine")
 
-restart-service docker
+Write-Host "Now restart the Docker engine to run LCOW"

--- a/scripts/update-docker-rc.ps1
+++ b/scripts/update-docker-rc.ps1
@@ -1,6 +1,6 @@
 Write-Host "Stopping docker service"
 Stop-Service docker
-$version = "17.09.0-ce-rc1"
+$version = "17.09.0-ce-rc2"
 
 Write-Host "Downloading docker-$version.zip"
 $wc = New-Object net.webclient


### PR DESCRIPTION
To enable LCOW - Linux Containers on Windows - we need to install a preview of LinuxKit and the nightly version of the Docker engine.
